### PR TITLE
Add scroll-triggered sticky navbar

### DIFF
--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -15,7 +15,20 @@ const Header = () => {
   const location = useLocation();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [openMenu, setOpenMenu] = useState(null);
+  const [hasScrolled, setHasScrolled] = useState(() => (
+    typeof window !== 'undefined' ? window.scrollY > 32 : false
+  ));
   const menuAreaRef = useRef(null);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setHasScrolled(window.scrollY > 32);
+    };
+
+    handleScroll();
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [location.pathname]);
 
   useEffect(() => {
     const handleClickOutside = (event) => {
@@ -88,6 +101,8 @@ const Header = () => {
     closeMenus();
     navigate('/builder', { state: { forceBlank: true } });
   };
+
+  const headerVisible = hasScrolled || mobileMenuOpen || Boolean(openMenu);
 
   const renderCreateMenu = (id) => (
     <div id={id} className={menuPanelClass} role="menu">
@@ -189,7 +204,9 @@ const Header = () => {
   );
 
   return (
-    <header className="relative z-[110] border-b border-gray-200 bg-white/95 py-4 backdrop-blur-sm transition-colors duration-200 dark:border-slate-700 dark:bg-slate-800/95">
+    <header className={`fixed inset-x-0 top-0 z-[110] border-b border-gray-200 bg-white/95 py-4 backdrop-blur-sm shadow-sm transition-[background-color,border-color,opacity,transform] duration-300 ease-out dark:border-slate-700 dark:bg-slate-800/95 ${
+      headerVisible ? 'translate-y-0 opacity-100' : 'pointer-events-none -translate-y-full opacity-0'
+    }`}>
       <div className="container mx-auto max-w-6xl px-4">
         <div className="flex items-center justify-between gap-4">
           <div className="flex min-w-0 items-center gap-4 lg:gap-8">


### PR DESCRIPTION
Fixes #15.

## Summary
- make the main header fixed and hidden at the top of the page
- reveal it smoothly after the user scrolls or while menus are open

## Verification
- npm run lint
- npm test
- npm run build